### PR TITLE
Ensure automated deploys leave the CNAME

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -51,3 +51,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: root
+          cname: sdk.smartcrypt.com 


### PR DESCRIPTION
The CNAME is necessary to serve our page at a custom URL.