### PR TITLE
Revert .NET site to be at /csharp

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -44,7 +44,7 @@ jobs:
         run: python3 -m pip install -r requirements-sphinx.txt
 
       - name: Build .NET site
-        run: sphinx-build -b html -t csharp dotnet/ root/dotnet
+        run: sphinx-build -b html -t csharp dotnet/ root/csharp
 
       - name: Deploy site
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/test_site.yml
+++ b/.github/workflows/test_site.yml
@@ -42,7 +42,7 @@ jobs:
         run: python3 -m pip install -r requirements-sphinx.txt
 
       - name: Build .NET site
-        run: sphinx-build -b html -t csharp dotnet/ root/dotnet
+        run: sphinx-build -b html -t csharp dotnet/ root/csharp
 
       - name: Test site
         working-directory: root

--- a/root/index.html
+++ b/root/index.html
@@ -50,7 +50,7 @@
                     <!-- <img src="logo_dotnet.svg" /> -->
                     <h5 class="card-title">.NET</h5>
                     <p class="card-text">.NET Core and .NET Framework</p>
-                    <a href="dotnet" class="btn btn-primary">Get started</a>
+                    <a href="csharp" class="btn btn-primary">Get started</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
We have existing links point to /csharp that we've sent to customers. This seems easier than setting up page redirects.